### PR TITLE
Fix legend css

### DIFF
--- a/js/parking_map.js
+++ b/js/parking_map.js
@@ -49,13 +49,15 @@ function renderLoader() {
 
 function removeLoader() {
   let loader = document.querySelector('.loader');
-  document.body.removeChild(loader);
+  if (loader) document.body.removeChild(loader);
 }
 
 let featuresLayerGroup
 
 function queryArcGIS(map) {
-  renderLoader();
+
+  let loader = document.querySelector('.loader');
+  if (!loader) renderLoader();
   conditions = []
 
   conditions.push('even_is_parking_available IS NOT NULL AND odd_is_parking_available IS NOT NULL')

--- a/js/parking_map.js
+++ b/js/parking_map.js
@@ -41,9 +41,21 @@ function getPaymentMethods(val) {
   }
 }
 
+function renderLoader() {
+  let loader = document.createElement('div');
+  loader.className = 'loader';
+  document.body.insertBefore(loader, document.body.firstChild);
+}
+
+function removeLoader() {
+  let loader = document.querySelector('.loader');
+  document.body.removeChild(loader);
+}
+
 let featuresLayerGroup
 
 function queryArcGIS(map) {
+  renderLoader();
   conditions = []
 
   conditions.push('even_is_parking_available IS NOT NULL AND odd_is_parking_available IS NOT NULL')
@@ -120,18 +132,19 @@ function queryArcGIS(map) {
 
         } else {
           lines.push('No parking available')
-
         }
-
         return lines.join('<br>')
 
-      }).addTo(map)
+      }).addTo(map);
+
+      removeLoader();
 
     }
   })
 }
 
 $(document).ready(() => {
+
   const map = L.map("parking-map").setView([39.743624, -75.549839], 15);
 
   const parkingGarages = new L.GeoJSON.AJAX("https://gist.githubusercontent.com/trescube/14dc08c9fe1d115308176efe88fb05dd/raw/230791df013d36bac441048fecba79b03c0a6916/wilmington_parking_garages.geojson", {
@@ -146,7 +159,7 @@ $(document).ready(() => {
   queryArcGIS(map)
 
   parkingGarages.addTo(map);
-
+  
   parkingGarages.bindTooltip(parkingGarage => {
     const properties = parkingGarage.feature.properties
 
@@ -160,12 +173,12 @@ $(document).ready(() => {
   })
 
   $('.leaflet-control-layers').css({ 'width': '100', 'float': 'right' });
-
   $('#hasMeters').change(queryArcGIS.bind(null, map))
   $('#acceptsCreditCards').change(queryArcGIS.bind(null, map))
   $('#acceptsParkMobile').change(queryArcGIS.bind(null, map))
   $('#acceptsCoins').change(queryArcGIS.bind(null, map))
   $('#freeSaturdayParking').change(queryArcGIS.bind(null, map))
   $('#freeSundayParking').change(queryArcGIS.bind(null, map))
-})
+
+});
 

--- a/js/parking_map_data_control.js
+++ b/js/parking_map_data_control.js
@@ -10,7 +10,7 @@ L.Control.ParkingInput = L.Control.extend({
 
     const inputPanel = L.DomUtil.create('div', 'panel panel-default', container)
     inputPanel.innerHTML = 
-      '<h3>Wilmington, DE</h3>' +
+      '<h4>Wilmington, DE</h4>' +
       '<form id="filter-parking-form">' +
         '<div>' +
         '<label>' +

--- a/parking_map.css
+++ b/parking_map.css
@@ -1,0 +1,69 @@
+body { 
+    margin:0; 
+    padding:0; 
+}
+
+#parking-map { 
+    position: absolute; 
+    top:0; 
+    bottom:0; 
+    right:0; 
+    left:0; 
+    z-index: 0; 
+}
+
+#parking-map .container .panel.panel-default { 
+    display: flex; 
+    flex-direction: column; 
+    justify-content: center; 
+    align-items: flex-start; 
+    padding: 5px; 
+    max-width: 30vw; 
+    max-height: 40vh; 
+    min-width: 200px; 
+    min-height: 200px; 
+    float: right; 
+    background-color: rgba(255,255,255,0.8);
+    box-shadow: 0px 2px 1px 0px;
+}
+
+#parking-map #filter-parking-form { 
+    margin: 0px; 
+}
+
+#parking-map #filter-parking-form input { 
+    vertical-align: text-bottom; 
+}
+
+#parking-map h4 { 
+    font-weight: 900; 
+    margin: 5px 0px 5px 0px 
+}
+
+@keyframes spin { 
+  0% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(0deg); } 
+  50% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(0,0,200); border-bottom: 16px solid rgb(0,0,200); transform: rotate(180deg); }     
+  100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(360deg); }
+}    
+
+@-webkit-keyframes spin { 
+    0% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(0deg); } 
+    50% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(0,0,200); border-bottom: 16px solid rgb(0,0,200); transform: rotate(180deg); }     
+    100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(360deg); }
+  }    
+
+.loader { 
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 25vh;
+    left: 25vw;
+    margin-top: calc(25vh - 50px);
+    margin-bottom: calc(25vh - 50px);
+    margin-left: calc(25vw - 50px);
+    margin-right: calc(25vw - 50px);
+    border-radius: 50%;
+    z-index: 100;
+    animation: spin 3s linear infinite;
+    -webkit-animation: spin 3s linear infinite;
+}

--- a/parking_map.css
+++ b/parking_map.css
@@ -50,7 +50,13 @@ body {
     0% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); -webkit-transform: rotate(0deg); } 
     50% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(0,0,200); border-bottom: 16px solid rgb(0,0,200); -webkit-transform: rotate(180deg); }     
     100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); -webkit-transform: rotate(360deg); } 
-  }    
+}
+
+@-ms-keyframes msspin { 
+    0% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); -webkit-transform: rotate(0deg); } 
+    50% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(0,0,200); border-bottom: 16px solid rgb(0,0,200); -webkit-transform: rotate(180deg); }     
+    100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); -webkit-transform: rotate(360deg); } 
+}    
 
 .loader { 
     position: absolute;
@@ -69,4 +75,5 @@ body {
     z-index: 100;
     animation: spin 3s linear infinite;
     -webkit-animation: safarispin 3s linear infinite;
+    -ms-animation: msspin 3s linear infinite;
 }

--- a/parking_map.css
+++ b/parking_map.css
@@ -46,10 +46,10 @@ body {
   100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(360deg); }
 }    
 
-@-webkit-keyframes spin { 
-    0% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(0deg); } 
-    50% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(0,0,200); border-bottom: 16px solid rgb(0,0,200); transform: rotate(180deg); }     
-    100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); transform: rotate(360deg); }
+@-webkit-keyframes safarispin { 
+    0% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); -webkit-transform: rotate(0deg); } 
+    50% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(0,0,200); border-bottom: 16px solid rgb(0,0,200); -webkit-transform: rotate(180deg); }     
+    100% { border: 16px solid rgba(0,0,0,0); border-top: 16px solid rgb(200,0,0); border-bottom: 16px solid rgb(200,0,0); -webkit-transform: rotate(360deg); } 
   }    
 
 .loader { 
@@ -63,7 +63,10 @@ body {
     margin-left: calc(25vw - 50px);
     margin-right: calc(25vw - 50px);
     border-radius: 50%;
+    border: 16px solid rgba(0,0,0,0); 
+    border-top: 16px solid rgb(0,0,0); 
+    border-bottom: 16px solid rgb(0,0,0);
     z-index: 100;
     animation: spin 3s linear infinite;
-    -webkit-animation: spin 3s linear infinite;
+    -webkit-animation: safarispin 3s linear infinite;
 }

--- a/parking_map.html
+++ b/parking_map.html
@@ -8,6 +8,8 @@
   integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
   crossorigin="anonymous">
 
+  <link rel="stylesheet" href="parking_map.css" />
+
   <!-- Load Leaflet from CDN -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"
   integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
@@ -26,15 +28,6 @@
   <script src="https://js.arcgis.com/4.7/"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-ajax/2.1.0/leaflet.ajax.js"></script>
 
-  <style>
-    body { margin:0; padding:0; }
-    #parking-map { position: absolute; top:0; bottom:0; right:0; left:0; }
-    #parking-map .container .panel.panel-default { display: flex; flex-direction: column; justify-content: center; align-items: flex-start; 
-      padding: 5px; max-width: 30vw; max-height: 40vh; min-width: 250px; min-height: 200px; float: right; }
-    #parking-map #filter-parking-form { margin: 0px; }
-    #parking-map #filter-parking-form input { vertical-align: text-bottom; }
-    #parking-map h3 { font-weight: 900; margin: 5px 0px 5px 0px }
-  </style>
 </head>
 <body>
   <div id="parking-map"></div>


### PR DESCRIPTION
Because a request is being made and processed each time a selection is checked or unchecked, I would expect that it can occasionally take awhile for the map to rerender with the newly selected or unselected options. This happened to me yesterday with a slow internet connection. It occurred to me that a slow connection might also happen for someone driving in a car trying to find parking. To denote to the user that their selections (or unselections) have been processed, I added a loader to the screen to denote that the map is reloading. Pictures are included below. It works in Chrome, Firefox, Safari and Edge. 

I've also made the legend a bit more transparent to allow the user to see if parking maps are beneath it.

![on_load](https://user-images.githubusercontent.com/30197114/45273766-1cfeaa00-b482-11e8-9a2f-f52d8a2c9e67.PNG)
![once_map_renders](https://user-images.githubusercontent.com/30197114/45273767-1cfeaa00-b482-11e8-965b-7945cf87ce99.PNG)
![immediately_after_map_render](https://user-images.githubusercontent.com/30197114/45273768-1cfeaa00-b482-11e8-9158-e01019c0d5a9.PNG)
